### PR TITLE
Spam_model: remove _cloud_report (privacy threat)

### DIFF
--- a/application/config/kalkun_settings.php
+++ b/application/config/kalkun_settings.php
@@ -61,18 +61,6 @@ $config['gammu_path'] = 'C:\Gammu 1.29.92\bin';
 $config['gammu_sms_inject'] = $config['gammu_path'].DIRECTORY_SEPARATOR.'gammu-smsd-inject';
 $config['gammu_config'] = $config['gammu_path'].DIRECTORY_SEPARATOR.'config.ini';
 
-
-/*
-|--------------------------------------------------------------------------
-|   Kalkun Cloud Feature Network Settings
-|--------------------------------------------------------------------------
-*/
-$config['enable_proxy'] = FALSE;
-$config['proxy_host'] = 'proxyhost.com';
-$config['proxy_port'] = '8080';
-$config['proxy_username'] = '';
-$config['proxy_password'] = '';
-
 /*
 |--------------------------------------------------------------------------
 | Conversation Grouping

--- a/application/models/Spam_model.php
+++ b/application/models/Spam_model.php
@@ -99,8 +99,6 @@ class Spam_model extends CI_Model {
 		//move message to spam folder
 		$this->db->where('ID', $params['ID']);
 		$this->db->update('inbox', array('id_folder' => '6'));
-
-		$this->_cloud_report('spam', $params['Text']);
 	}
 
 	/**
@@ -116,33 +114,5 @@ class Spam_model extends CI_Model {
 		//move message to spam folder
 		$this->db->where('ID', $params['ID']);
 		$this->db->update('inbox', array('id_folder' => '1'));
-
-		$this->_cloud_report('ham', $params['Text']);
-	}
-
-	/**
-	 * Spam_model::_cloud_report()
-	 *
-	 * @param mixed $type
-	 * @param mixed $text
-	 * @return
-	 */
-	function _cloud_report($type, $text)
-	{
-		$this->load->library('curl');
-		$this->curl->create('http://digitalplantation.org/kalkun/cloudspam/report.php');
-		$post = array('type' => $type, 'msg' => $text);
-		$this->curl->post($post);
-
-		if ($this->config->item('enable_proxy'))
-		{
-			$this->curl->proxy($this->config->item('proxy_host'), $this->config->item('proxy_port'));
-			if ($this->config->item('proxy_username') !== '')
-			{
-				$this->curl->proxy_login($this->config->item('proxy_username'), $this->config->item('proxy_password'));
-			}
-		}
-
-		echo $this->curl->execute();
 	}
 }


### PR DESCRIPTION
Since:
  - this is a privacy threat (it reports the text of the SMS on a server)
  - the digitalplantation.org server reports 403 Forbidden
  - this is very old

Simply remove it