### PR TITLE
Plugins: Make plugin an anchor only if controller has index method

### DIFF
--- a/application/controllers/Pluginss.php
+++ b/application/controllers/Pluginss.php
@@ -60,6 +60,10 @@ class Pluginss extends MY_Controller {
 		{
 			$data['title'] .= lang('pluginss_installed');
 			$data['plugins'] = $this->Plugin_model->get_plugins()->result_array();
+			foreach ($data['plugins'] as $key => $plugin)
+			{
+				$data['plugins'][$key]['plugin_controller_has_index'] = $this->_plugin_controller_has_index($plugin['plugin_system_name']);
+			}
 		}
 		else
 		{
@@ -172,5 +176,26 @@ class Pluginss extends MY_Controller {
 	function _plugins_cmp_plugin_name($p1, $p2)
 	{
 		return strcasecmp ($p1['plugin_name'], $p2['plugin_name']);
+	}
+
+	// --------------------------------------------------------------------
+
+	/**
+	 * Check if the controller of the plugin has a 'index()' method
+	 */
+	function _plugin_controller_has_index($plugin_system_name)
+	{
+		$controller_class = ucfirst($plugin_system_name);
+		$controller_path = APPPATH . 'plugins/'.$plugin_system_name.'/controllers/'.$controller_class.'.php';
+
+		if ( ! file_exists($controller_path))
+		{
+			return FALSE;
+		}
+
+		require_once $controller_path;
+		$rc = new ReflectionClass($controller_class);
+
+		return $rc->hasMethod('index');
 	}
 }

--- a/application/views/main/plugin/index.php
+++ b/application/views/main/plugin/index.php
@@ -17,7 +17,9 @@ if (count($plugins) > 0)
 {
 	foreach ($plugins as $tmp)
 	{
-		if ($type == 'installed' AND file_exists(APPPATH . 'plugins/'.$tmp['plugin_system_name'].'/controllers/'.ucfirst($tmp['plugin_system_name']).'.php'))
+		if ($type === 'installed'
+			&& file_exists(APPPATH . 'plugins/'.$tmp['plugin_system_name'].'/controllers/'.ucfirst($tmp['plugin_system_name']).'.php')
+			&& $tmp['plugin_controller_has_index'] === TRUE)
 		{
 			echo '<div style="float: left"><h3>'.anchor('plugin/'.$tmp['plugin_system_name'], $tmp['plugin_name']).'</h3></div>';
 		}


### PR DESCRIPTION
Fixes 404 error when user clicked on a plugin name on the plugins page.
This was because the controller of the plugin didn't provide a "index()" method