### PR TITLE
server-alert plugin: fix SQL crash on adding server alert

### DIFF
--- a/application/plugins/server_alert/models/Server_alert_model.php
+++ b/application/plugins/server_alert/models/Server_alert_model.php
@@ -56,6 +56,7 @@ class Server_alert_model extends CI_Model {
 			'timeout' => trim($this->input->post('timeout', TRUE)),
 			'phone_number' => trim($this->input->post('phone_number', TRUE)),
 			'respond_message' => $this->input->post('respond_message', TRUE),
+			'release_code' => '', // Not used for now (db requires NOT NULL)
 		);
 		$this->db->insert('plugin_server_alert', $data);
 	}


### PR DESCRIPTION
SQL table for server-alert plugin has column 'release_code' which has NOT NULL.
For now release_code is used nowhere. We set its value to -1 to circumvent the
reported SQL error