### PR TITLE
sms_credit plugin: fix wrong password when creating user

### DIFF
--- a/application/plugins/sms_credit/controllers/Sms_credit.php
+++ b/application/plugins/sms_credit/controllers/Sms_credit.php
@@ -83,24 +83,15 @@ class Sms_credit extends Plugin_controller {
 	{
 		if ($_POST)
 		{
-			$param['id_user'] = $this->input->post('id_user');
-			$param['id_template_credit'] = $this->input->post('package');
-			$param['valid_start'] = $this->input->post('package_start');
-			$param['valid_end'] = $this->input->post('package_end');
-
-			if (empty($param['id_user']))
+			if (empty($this->input->post('id_user')))
 			{
-				unset($param['id_user']);
-				$param['realname'] = trim($this->input->post('realname'));
-				$param['username'] = trim($this->input->post('username'));
-				$param['phone_number'] = $this->input->post('phone_number');
-				$param['level'] = $this->input->post('level');
-				$param['password'] = sha1($this->input->post('password'));
-				$this->plugin_model->add_users($param);
+				// add user
+				$this->plugin_model->add_users();
 			}
 			else
 			{
-				$this->plugin_model->change_users_package($param);
+				// edit user
+				$this->plugin_model->change_users_package();
 			}
 
 			redirect('plugin/sms_credit');

--- a/application/plugins/sms_credit/models/Sms_credit_model.php
+++ b/application/plugins/sms_credit/models/Sms_credit_model.php
@@ -82,36 +82,17 @@ class Sms_credit_model extends CI_Model {
 	 */
 	function add_users($param = array())
 	{
-		if (isset($param['id_template_credit']))
-		{
-			$package['id_template_credit'] = $param['id_template_credit'];
-			$package['valid_start'] = $param['valid_start'];
-			$package['valid_end'] = $param['valid_end'];
-			unset($param['id_template_credit']);
-			unset($param['valid_start']);
-			unset($param['valid_end']);
-		}
+		$this->load->model('User_model');
 
-		// start transcation
 		$this->db->trans_start();
-		$this->db->insert('user', $param);
 
-		// user_settings
-		$user_id = $this->db->insert_id();
-		$this->db->set('theme', 'blue');
-		$this->db->set('signature', 'false;');
-		$this->db->set('permanent_delete', 'false');
-		$this->db->set('paging', '20');
-		$this->db->set('bg_image', 'true;background.jpg');
-		$this->db->set('delivery_report', 'default');
-		$this->db->set('language', 'english');
-		$this->db->set('conversation_sort', 'asc');
-		$this->db->set('id_user', $user_id);
-		$this->db->insert('user_settings');
+		$this->User_model->addUser();
 
-		// packages
-		$package['id_user'] = $user_id;
-		$this->db->insert('plugin_sms_credit', $package);
+		$param['id_user'] = $this->User_model->search_user(trim($this->input->post('realname')))->row('id_user');
+		$param['id_template_credit'] = $this->input->post('package');
+		$param['valid_start'] = $this->input->post('package_start');
+		$param['valid_end'] = $this->input->post('package_end');
+		$this->db->insert('plugin_sms_credit', $param);
 
 		$this->db->trans_complete();
 	}
@@ -126,14 +107,11 @@ class Sms_credit_model extends CI_Model {
 	 */
 	function delete_users($id_user = NULL)
 	{
+		$this->load->model('User_model');
+
 		$this->db->trans_start();
 		$this->db->delete('plugin_sms_credit', array('id_user' => $id_user));
-		$this->db->delete('sms_used', array('id_user' => $id_user));
-		$this->db->delete('user_folders', array('id_user' => $id_user));
-		$this->db->delete('pbk', array('id_user' => $id_user));
-		$this->db->delete('pbk_groups', array('id_user' => $id_user));
-		$this->db->delete('user_settings', array('id_user' => $id_user));
-		$this->db->delete('user', array('id_user' => $id_user));
+		$this->User_model->delUsers($id_user);
 		$this->db->trans_complete();
 	}
 
@@ -151,11 +129,17 @@ class Sms_credit_model extends CI_Model {
 		// start transcation
 		$this->db->trans_start();
 
+		$param['id_user'] = $this->input->post('id_user');
+		$param['id_template_credit'] = $this->input->post('package');
+		$param['valid_start'] = $this->input->post('package_start');
+		$param['valid_end'] = $this->input->post('package_end');
+
 		// Delete user package first
 		$this->db->delete('plugin_sms_credit', array('id_user' => $param['id_user']));
 
 		// insert package
 		$this->db->insert('plugin_sms_credit', $param);
+
 		$this->db->trans_complete();
 	}
 


### PR DESCRIPTION
sms_credit plugin permits to create a new user in Kalkun.

The code to create the user was not up to date and diverged from the one in
User_model.

Now sms_credit uses the code in User_model to avoid duplication of code

Same change was applied user deletion through sms_credit plugin