### PR TITLE
add contact: close underlying dialog when openning the new one

### DIFF
--- a/application/views/js_init/phonebook/js_phonebook.php
+++ b/application/views/js_init/phonebook/js_phonebook.php
@@ -14,6 +14,7 @@ $(document).ready(function() {
 	}
 	else
 	{
+		$('#pbk_add_wizard_dialog').dialog('close');
 		if($(this).hasClass('addpbkcontact')) {
 			var pbk_title = '<?php echo lang('tni_contact_add'); ?>';
 			var type = 'normal';
@@ -206,10 +207,11 @@ $(document).ready(function() {
 		
 	// Contact import
 	$('#importpbk').click(function() {
+		$('#pbk_add_wizard_dialog').dialog('close');
 		$("#pbkimportdialog").dialog({
 			bgiframe: true,
 			autoOpen: false,
-			height: 300,
+			height: 350,
 			modal: true,
 			buttons: {
 				'Import': function() {


### PR DESCRIPTION
When adding contact in the phonebook, a 1st dialog appears asking whether to
create a signe contact or import from CSV. When chosing one, the dialog remained
in the background, and when addition was finished, it was still there what
is annoying. So close it when we open the new one.

+ increase height of CSV import dialog. It was a bit too short